### PR TITLE
Pinned Python Dependencies and Fixed label_binarize Named Parameter Call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Changed
 - Dependencies in `requirements.txt` to be pinned to specific versions that `0.4.1` will run with.
-- Calling of `label_binarizer` to use `classes` keyword arg in Scikit-learn.
+- Calling of `label_binarize` to use `classes` keyword arg in Scikit-learn.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [0.4.1] - 2022-12-27
+### Added
+- Changelog starting at version `0.4.1`
+
+### Changed
+- Dependencies in `requirements.txt` to be pinned to specific versions that `0.4.1` will run with.
+- Calling of `label_binarizer` to use `classes` keyword arg in Scikit-learn.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.4.1] - 2022-12-27
+## [0.4.1](https://github.com/dirichletcal/dirichlet_python/issues/14) - 2022-12-27
 ### Added
 - Changelog starting at version `0.4.1`
 

--- a/dirichletcal/calib/multinomial.py
+++ b/dirichletcal/calib/multinomial.py
@@ -86,7 +86,7 @@ class MultinomialRegression(BaseEstimator, RegressorMixin):
                 self.reg_lambda = self.reg_lambda / (k * (k - 1))
                 self.reg_mu = self.reg_mu / k
 
-        target = label_binarize(y, self.classes)
+        target = label_binarize(y, classes=self.classes)
 
         if k == 2:
             target = np.hstack([1-target, target])
@@ -274,7 +274,7 @@ def _newton_update(weights_0, X, XX_T, target, k, method_, maxiter=int(1024),
             updates = gradient / hessian
         else:
             try:
-                inverse = scipy.linalg.pinv2(hessian)
+                inverse = scipy.linalg.pinv(hessian)
                 updates = np.matmul(inverse, gradient)
             except (raw_np.linalg.LinAlgError, ValueError) as err:
                 logging.error(err)

--- a/dirichletcal/utils.py
+++ b/dirichletcal/utils.py
@@ -11,6 +11,7 @@ def clip(X):
     eps = np.finfo(X.dtype).tiny
     return np.clip(X, eps, 1-eps)
 
+    
 def clip_jax(X):
     eps = jax_np.finfo(X.dtype).eps
     return jax_np.clip(X, eps, 1-eps)

--- a/dirichletcal/version.py
+++ b/dirichletcal/version.py
@@ -1,1 +1,1 @@
-__version__="0.3.dev4"
+__version__="0.4.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy
-scipy
-scikit-learn
-jax
-jaxlib
-autograd
+numpy==1.19.5
+scipy==1.9.3
+scikit-learn==1.2.0
+jax==0.2.10
+jaxlib==0.1.60
+autograd==1.5


### PR DESCRIPTION
This PR includes the following:

### Added
- Changelog starting at version `0.4.1`

### Changed
- Dependencies in `requirements.txt` to be pinned to specific versions that `0.4.1` will run with.
- Calling of `label_binarize` to use `classes` keyword arg in Scikit-learn.

Associated issue: https://github.com/dirichletcal/dirichlet_python/issues/14